### PR TITLE
App update

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -10,7 +10,7 @@ import Signup from './pages/Signup';
 import AllCustomers from './pages/AllCustomers';
 import SingleCustomer from './pages/SingleCustomer';
 import NoMatch from './pages/NoMatch';
-
+import Auth from '../src/utils/auth'
 
 
 
@@ -19,7 +19,6 @@ import NoMatch from './pages/NoMatch';
 import { ApolloProvider } from '@apollo/react-hooks';
 import ApolloClient from 'apollo-boost';
 
-// borrowed from the classwork, will uncomment when the JWT auth is set up
 const client = new ApolloClient({
     request: (operation) => {
         const token = localStorage.getItem('id_token')
@@ -35,7 +34,7 @@ const client = new ApolloClient({
 function App() {
     const [pages] = useState(["dashboard", "customers", "sales", "other"]);
     const [pageSelected, setPageSelected] = useState(pages[0]);
-
+    const loggedIn = Auth.loggedIn()
     return (
         <ApolloProvider client={client}>
             <Router>
@@ -43,17 +42,20 @@ function App() {
                     <Header pageSelected={pageSelected}
                         setPageSelected={setPageSelected} />
                     <main className="">
-                        <Switch>
-                            <Route exact path = '/' component = {Login}/>
-                            <Route exact path = '/signup' component = {Signup}/>
-                            <Route exact path = '/dashboard' component = {Dashboard}/>
-                            <Route exact path = '/customers/' component = {AllCustomers}/>
-                            {/* <Route exact path = '/:id/:customerid' component = {SingleCustomer}/> */}
-
-
-                            <Route component ={NoMatch}/>
-                        </Switch>
-
+                        {loggedIn ? (
+                                <Switch>
+                                <Route exact path = '/' component = {Dashboard}/>
+                                <Route exact path = '/signup' component = {Signup}/>
+                                <Route exact path = '/customers' component = {AllCustomers}/>
+                                {/* <Route exact path = '/customers/:customerId' component = {SingleCustomer}/> */}
+                                <Route component ={NoMatch}/>
+                                </Switch>
+                            ) : (
+                                <Switch>
+                                <Route exact path = '/signup' component = {Signup}/>
+                                <Route component = {Login} />
+                                </Switch>
+                            )}
                     </main>
                     <Footer>
                         

--- a/client/src/pages/Signup/index.js
+++ b/client/src/pages/Signup/index.js
@@ -7,11 +7,14 @@ import Auth from '../../utils/auth';
 import logo from '../../assets/colossal-logo.png';
 
 const Signup = () => {
+
     const [formState, setFormState] = useState({ firstName : '', lastName: '', email: '', password: ''})
 
     const [addEmployee, { error }] = useMutation(ADD_EMPLOYEE);
-
-    
+    const loggedIn = Auth.loggedIn()
+    if (loggedIn) {
+        return window.location.assign('/')
+    }
     const handleChange = (event) =>{
         const {name,value} = event.target
 

--- a/client/src/utils/auth.js
+++ b/client/src/utils/auth.js
@@ -31,7 +31,7 @@ class AuthService {
     // Saves user token to localStorage
     localStorage.setItem('id_token', idToken);
 
-    window.location.assign('/dashboard');
+    window.location.assign('/');
   }
 
   logout() {


### PR DESCRIPTION
Refactored the Router logic in App to only let a user access Signup or Login if they aren't logged in, with this approach we won't have to do any checks for this in the individual components. I did leave one check on the Signup component, since I thought it would be weird if going to /signup when you're logged in gave you the "Nothing Found" page. I made it so navigating to /signup when you're logged in doesn't display anything then immediately redirects you to the dashboard